### PR TITLE
Enhanced Recrawl Logic with Script Support

### DIFF
--- a/module/core/core_network/lib/src/manager/headless_webview_manager.dart
+++ b/module/core/core_network/lib/src/manager/headless_webview_manager.dart
@@ -313,6 +313,10 @@ class HeadlessWebviewManager implements HeadlessWebviewUseCase {
       delegate.onRunJavascript(script: script);
     }
 
+    if (scripts.isNotEmpty) {
+      await Future.delayed(const Duration(seconds: 1));
+    }
+
     if (signalComplete != null) {
       try {
         await signalComplete.timeout(const Duration(seconds: 15));

--- a/module/core/core_network/lib/src/manager/headless_webview_manager.dart
+++ b/module/core/core_network/lib/src/manager/headless_webview_manager.dart
@@ -20,16 +20,18 @@ class _Key extends Equatable {
   final List<String> scripts;
   final bool useCache;
   final Map<String, String> headers;
+  final Duration? timeout;
 
   const _Key({
     required this.url,
     this.scripts = const [],
     required this.useCache,
     this.headers = const {},
+    this.timeout,
   });
 
   @override
-  List<Object?> get props => [url, scripts, useCache, headers];
+  List<Object?> get props => [url, scripts, useCache, headers, timeout];
 }
 
 class HeadlessWebviewManager implements HeadlessWebviewUseCase {
@@ -59,11 +61,22 @@ class HeadlessWebviewManager implements HeadlessWebviewUseCase {
     String url, {
     List<String> scripts = const [],
     bool useCache = true,
+    Duration? timeout,
   }) {
-    final key = _Key(url: url, useCache: useCache, scripts: scripts);
+    final key = _Key(
+      url: url,
+      useCache: useCache,
+      scripts: scripts,
+      timeout: timeout,
+    );
     return _cDocument.putIfAbsent(
       key,
-      () => _open(url, scripts: scripts, useCache: useCache).whenComplete(() {
+      () => _open(
+        url,
+        scripts: scripts,
+        useCache: useCache,
+        timeout: timeout,
+      ).whenComplete(() {
         _cDocument.remove(key);
       }),
     );
@@ -74,11 +87,22 @@ class HeadlessWebviewManager implements HeadlessWebviewUseCase {
     String url, {
     bool useCache = true,
     Map<String, String>? headers,
+    Duration? timeout,
   }) {
-    final key = _Key(url: url, useCache: useCache, headers: headers ?? {});
+    final key = _Key(
+      url: url,
+      useCache: useCache,
+      headers: headers ?? {},
+      timeout: timeout,
+    );
     return _cImage.putIfAbsent(
       key,
-      () => _image(url, headers: headers, useCache: useCache).whenComplete(() {
+      () => _image(
+        url,
+        headers: headers,
+        useCache: useCache,
+        timeout: timeout,
+      ).whenComplete(() {
         _cImage.remove(key);
       }),
     );
@@ -88,6 +112,7 @@ class HeadlessWebviewManager implements HeadlessWebviewUseCase {
     String url, {
     List<String> scripts = const [],
     bool useCache = true,
+    Duration? timeout,
   }) async {
     return parse(
       await _fetch(
@@ -95,6 +120,7 @@ class HeadlessWebviewManager implements HeadlessWebviewUseCase {
         scripts: scripts,
         delegate: _log.inAppWebviewObserver,
         useCache: useCache,
+        timeout: timeout,
       ),
       sourceUrl: url,
     );
@@ -104,6 +130,7 @@ class HeadlessWebviewManager implements HeadlessWebviewUseCase {
     String url, {
     bool useCache = true,
     Map<String, String>? headers,
+    Duration? timeout,
   }) async {
     final Completer<String> completer = Completer();
 
@@ -117,6 +144,7 @@ class HeadlessWebviewManager implements HeadlessWebviewUseCase {
       uri: WebUri(url),
       delegate: _log.inAppWebviewObserver,
       useCache: useCache,
+      timeout: timeout,
       scripts: [
         '''
         const toDataURL = url => fetch(url $stringHeaders)
@@ -192,6 +220,7 @@ class HeadlessWebviewManager implements HeadlessWebviewUseCase {
     List<String> scripts = const [],
     bool useCache = true,
     Future? signalComplete,
+    Duration? timeout,
   }) async {
     delegate.set(uri: uri, loading: true);
     final key = [uri.toString(), ...scripts].join('|');
@@ -294,11 +323,19 @@ class HeadlessWebviewManager implements HeadlessWebviewUseCase {
     _instances[webview.hashCode] = webview;
 
     try {
-      await Future.wait([
-        webview.run(),
-        onLoadStartCompleter.future,
-        Future.any([onLoadStopCompleter.future, onLoadErrorCompleter.future]),
-      ]).timeout(const Duration(seconds: 15));
+      if (timeout != null) {
+        await Future.wait([
+          webview.run(),
+          onLoadStartCompleter.future,
+          Future.any([onLoadStopCompleter.future, onLoadErrorCompleter.future]),
+        ]).timeout(const Duration(seconds: 15));
+      } else {
+        await Future.wait([
+          webview.run(),
+          onLoadStartCompleter.future,
+          Future.any([onLoadStopCompleter.future, onLoadErrorCompleter.future]),
+        ]);
+      }
     } catch (e, st) {
       delegate.set(error: e, stackTrace: st, loading: false);
       _instances.remove(webview.hashCode);
@@ -314,13 +351,17 @@ class HeadlessWebviewManager implements HeadlessWebviewUseCase {
     }
 
     if (signalComplete != null) {
-      try {
-        await signalComplete.timeout(const Duration(seconds: 15));
-      } catch (e, st) {
-        delegate.set(error: e, stackTrace: st, loading: false);
-        _instances.remove(webview.hashCode);
-        await webview.dispose();
-        rethrow;
+      if (timeout != null) {
+        try {
+          await signalComplete.timeout(const Duration(seconds: 15));
+        } catch (e, st) {
+          delegate.set(error: e, stackTrace: st, loading: false);
+          _instances.remove(webview.hashCode);
+          await webview.dispose();
+          rethrow;
+        }
+      } else {
+        await signalComplete;
       }
     }
 

--- a/module/domain/domain_manga/lib/src/sources/asura_scan_source_external.dart
+++ b/module/domain/domain_manga/lib/src/sources/asura_scan_source_external.dart
@@ -72,7 +72,7 @@ class _GetChapterImageSourceExternalUseCase
       'var elements = document.querySelectorAll(\'$query\');',
       '''
       for (let i = 0; i < elements.length; i++) {
-        setTimeout(() => elements[i].scrollIntoView(), 100 * i);
+        setTimeout(() => elements[i].scrollIntoView(), 500 * i);
       }
       ''',
     ];

--- a/module/domain/domain_manga/lib/src/sources/asura_scan_source_external.dart
+++ b/module/domain/domain_manga/lib/src/sources/asura_scan_source_external.dart
@@ -40,6 +40,10 @@ class AsuraScanSourceExternal implements SourceExternal {
 
 class _GetChapterImageSourceExternalUseCase
     implements GetChapterImageSourceExternalUseCase {
+
+  @override
+  Duration? get timeout => Duration(seconds: 30);
+
   @override
   Future<List<String>> parse({required Document root}) async {
     final regions = root.querySelectorAll(
@@ -76,6 +80,10 @@ class _GetChapterImageSourceExternalUseCase
 }
 
 class _GetMangaSourceExternalUseCase implements GetMangaSourceExternalUseCase {
+
+  @override
+  Duration? get timeout => Duration(seconds: 20);
+
   @override
   Future<MangaScrapped> parse({required Document root}) async {
     final region = root.querySelector('div.px-4.py-5');
@@ -142,6 +150,9 @@ class _ListChapterSourceExternalUseCase
   const _ListChapterSourceExternalUseCase(this._baseUrl, this._name);
 
   @override
+  Duration? get timeout => Duration(seconds: 15);
+
+  @override
   Future<List<ChapterScrapped>> parse({required Document root}) async {
     final regions = root.querySelectorAll(
       'a.group.flex.items-center.justify-between.px-4.py-4.transition-colors',
@@ -186,6 +197,9 @@ class _SearchMangaSourceExternalUseCase
   final String _baseUrl;
 
   const _SearchMangaSourceExternalUseCase(this._baseUrl);
+
+  @override
+  Duration? get timeout => Duration(seconds: 15);
 
   @override
   Future<bool?> haveNextPage({required Document root}) async {
@@ -290,6 +304,10 @@ class _SearchMangaSourceExternalUseCase
 }
 
 class _ListTagSourceExternalUseCase implements ListTagSourceExternalUseCase {
+
+  @override
+  Duration? get timeout => Duration(seconds: 20);
+
   @override
   Future<List<TagScrapped>> parse({required Document root}) async {
     final genreQuery = [

--- a/module/domain/domain_manga/lib/src/sources/manga_clash_source_external.dart
+++ b/module/domain/domain_manga/lib/src/sources/manga_clash_source_external.dart
@@ -39,6 +39,10 @@ class MangaClashSourceExternal extends SourceExternal {
 
 class _GetChapterImageSourceExternalUseCase
     implements GetChapterImageSourceExternalUseCase {
+
+  @override
+  Duration? get timeout => Duration(seconds: 15);
+
   @override
   Future<List<String>> parse({required Document root}) async {
     final region = root.querySelector('.reading-content');
@@ -61,6 +65,10 @@ class _GetChapterImageSourceExternalUseCase
 }
 
 class _GetMangaSourceExternalUseCase implements GetMangaSourceExternalUseCase {
+
+  @override
+  Duration? get timeout => Duration(seconds: 15);
+
   @override
   Future<MangaScrapped> parse({required Document root}) async {
     final description = root
@@ -102,6 +110,10 @@ class _GetMangaSourceExternalUseCase implements GetMangaSourceExternalUseCase {
 
 class _ListChapterSourceExternalUseCase
     implements ListChapterSourceExternalUseCase {
+
+  @override
+  Duration? get timeout => Duration(seconds: 15);
+
   @override
   Future<List<ChapterScrapped>> parse({required Document root}) async {
     final List<ChapterScrapped> data = [];
@@ -145,6 +157,9 @@ class _SearchMangaSourceExternalUseCase
   final String _baseUrl;
 
   const _SearchMangaSourceExternalUseCase(this._baseUrl);
+
+  @override
+  Duration? get timeout => Duration(seconds: 15);
 
   @override
   Future<bool?> haveNextPage({required Document root}) async {
@@ -238,6 +253,10 @@ class _SearchMangaSourceExternalUseCase
 }
 
 class _ListTagSourceExternalUseCase implements ListTagSourceExternalUseCase {
+
+  @override
+  Duration? get timeout => Duration(seconds: 15);
+
   @override
   Future<List<TagScrapped>> parse({required Document root}) async {
     final region = root.querySelector('div.form-group.checkbox-group.row');

--- a/module/domain/domain_manga/lib/src/use_case/recrawl_use_case.dart
+++ b/module/domain/domain_manga/lib/src/use_case/recrawl_use_case.dart
@@ -17,27 +17,31 @@ class RecrawlUseCase {
   Future<void> execute({
     required BuildContext context,
     required String url,
+    List<String> scripts = const [],
   }) async {
     final uri = Uri.tryParse(url);
     if (uri == null) return;
     await _logBox.webview(
       context: context,
       uri: uri,
-      onTapSnapshot: (url, html) async {
-        if (url == null || html == null) return;
+      scripts: scripts,
+      onTapSnapshot: (url, html) => _snapshot(url, html, uri),
+    );
+  }
 
-        await _htmlCacheManager.putFile(
-          url,
-          utf8.encode(html),
-          fileExtension: 'html',
-          maxAge: const Duration(minutes: 30),
-        );
+  void _snapshot(String? url, String? html, Uri uri) async {
+    if (url == null || html == null) return;
 
-        _logBox.log(
-          name: runtimeType.toString(),
-          'Finish caching html for url [$uri]',
-        );
-      },
+    await _htmlCacheManager.putFile(
+      url,
+      utf8.encode(html),
+      fileExtension: 'html',
+      maxAge: const Duration(minutes: 30),
+    );
+
+    _logBox.log(
+      name: runtimeType.toString(),
+      'Finish caching html for url [$uri]',
     );
   }
 }

--- a/module/library/entity_manga_external/lib/src/source_external.dart
+++ b/module/library/entity_manga_external/lib/src/source_external.dart
@@ -19,16 +19,19 @@ abstract class SourceExternal {
 }
 
 abstract class GetMangaSourceExternalUseCase {
+  Duration? get timeout;
   List<String> get scripts;
   Future<MangaScrapped> parse({required Document root});
 }
 
 abstract class GetChapterImageSourceExternalUseCase {
+  Duration? get timeout;
   List<String> get scripts;
   Future<List<String>> parse({required Document root});
 }
 
 abstract class SearchMangaSourceExternalUseCase {
+  Duration? get timeout;
   List<String> get scripts;
   String url({required SearchMangaParameter parameter});
   Future<List<MangaScrapped>> parse({required Document root});
@@ -36,11 +39,13 @@ abstract class SearchMangaSourceExternalUseCase {
 }
 
 abstract class ListChapterSourceExternalUseCase {
+  Duration? get timeout;
   List<String> get scripts;
   Future<List<ChapterScrapped>> parse({required Document root});
 }
 
 abstract class ListTagSourceExternalUseCase {
+  Duration? get timeout;
   List<String> get scripts;
   Future<List<TagScrapped>> parse({required Document root});
 }

--- a/module/ui/ui_browse/lib/src/browse_manga_screen/browse_manga_screen_cubit.dart
+++ b/module/ui/ui_browse/lib/src/browse_manga_screen/browse_manga_screen_cubit.dart
@@ -81,7 +81,7 @@ class BrowseMangaScreenCubit extends Cubit<BrowseMangaScreenState>
 
     if (refresh) await _clearMangaCache();
 
-    await Future.wait([_fetchManga(), _fetchTags(useCache: refresh)]);
+    await Future.wait([_fetchManga(), _fetchTags(useCache: !refresh)]);
 
     emit(state.copyWith(isLoading: false));
   }

--- a/module/ui/ui_browse/lib/src/browse_manga_screen/browse_manga_screen_cubit.dart
+++ b/module/ui/ui_browse/lib/src/browse_manga_screen/browse_manga_screen_cubit.dart
@@ -206,7 +206,11 @@ class BrowseMangaScreenCubit extends Cubit<BrowseMangaScreenState>
   }
 
   void recrawl({required BuildContext context, required String url}) async {
-    await _recrawlUseCase.execute(context: context, url: url);
+    await _recrawlUseCase.execute(
+      context: context,
+      url: url,
+      scripts: state.source?.searchMangaUseCase.scripts ?? [],
+    );
     await init(refresh: true);
   }
 }

--- a/module/ui/ui_browse/lib/src/manga_detail_screen/manga_detail_screen_cubit.dart
+++ b/module/ui/ui_browse/lib/src/manga_detail_screen/manga_detail_screen_cubit.dart
@@ -378,7 +378,11 @@ class MangaDetailScreenCubit extends Cubit<MangaDetailScreenState>
   }
 
   void recrawl({required BuildContext context, required String url}) async {
-    _recrawlUseCase.execute(context: context, url: url);
+    _recrawlUseCase.execute(
+      context: context,
+      url: url,
+      scripts: state.source?.getMangaUseCase.scripts ?? [],
+    );
     await init(useCache: false);
   }
 }

--- a/module/ui/ui_browse/lib/src/manga_reader_screen/manga_reader_screen_cubit.dart
+++ b/module/ui/ui_browse/lib/src/manga_reader_screen/manga_reader_screen_cubit.dart
@@ -150,7 +150,11 @@ class MangaReaderScreenCubit extends Cubit<MangaReaderScreenState>
   }
 
   void recrawl({required BuildContext context, required String url}) async {
-    await _recrawlUseCase.execute(context: context, url: url);
+    await _recrawlUseCase.execute(
+      context: context,
+      url: url,
+      scripts: state.source?.getChapterImageUseCase.scripts ?? [],
+    );
     await init(useCache: false);
   }
 

--- a/module/ui/ui_browse/lib/src/widget/manga_grid_widget/manga_grid_widget_cubit.dart
+++ b/module/ui/ui_browse/lib/src/widget/manga_grid_widget/manga_grid_widget_cubit.dart
@@ -152,7 +152,11 @@ class MangaGridWidgetCubit extends Cubit<MangaGridWidgetState>
   }
 
   void recrawl({required BuildContext context, required String url}) async {
-    await _recrawlUseCase.execute(context: context, url: url);
+    await _recrawlUseCase.execute(
+      context: context,
+      url: url,
+      scripts: state.source?.searchMangaUseCase.scripts ?? [],
+    );
     await init(refresh: true);
   }
 


### PR DESCRIPTION
## Summary
Introduced configurable timeouts for `HeadlessWebviewManager` and enabled script execution support within the manual recrawl flow.

### Primary Changes:
- Added `timeout` support to `HeadlessWebviewManager` and `SourceExternal` interfaces to improve request reliability.
- Enhanced `RecrawlUseCase` and associated Cubits to support `scripts` execution during manual re-crawling.
- Implemented source-specific timeout configurations for `AsuraScanSourceExternal` and `MangaClashSourceExternal`.

### Secondary changes:
- Fixed `useCache` logic in `BrowseMangaScreenCubit` to correctly handle tag refreshing.
- Refactored `RecrawlUseCase` by extracting snapshot logic into a dedicated `_snapshot` method.
- Added a 1-second delay after script execution in `HeadlessWebviewManager` to ensure DOM updates are fully captured.
