### PR TITLE
Add Firebase App Distribution to Android CI workflow

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -48,6 +48,13 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: build/app/outputs/apk/release/app-release.apk
+      - name: 'Upload to Firebase Distribution'
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{secrets.FIREBASE_APP_ID}}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DISTRIBUTION }}
+          groups: owner
+          file: build/app/outputs/apk/release/app-release.apk
       - name: 'Find Comment'
         if: always() && github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v3


### PR DESCRIPTION
* Update `.github/workflows/android.yaml` to include a step for uploading the release APK to Firebase Distribution.
* Configure the distribution step to use the specified Firebase App ID, service credentials, and destination group.